### PR TITLE
Add a filename param to uploadFileToDisk

### DIFF
--- a/src/app/Models/Traits/HasUploadFields.php
+++ b/src/app/Models/Traits/HasUploadFields.php
@@ -27,8 +27,9 @@ trait HasUploadFields
      * @param  string  $attribute_name  Model attribute name (and column in the db).
      * @param  string  $disk  Filesystem disk used to store files.
      * @param  string  $destination_path  Path in disk where to store the files.
+     * @param  string  $destination_filename  Optional filename for the stored file (without the extension)
      */
-    public function uploadFileToDisk($value, $attribute_name, $disk, $destination_path)
+    public function uploadFileToDisk($value, $attribute_name, $disk, $destination_path, $destination_filename = null)
     {
         // if a new file is uploaded, delete the file from the disk
         if (request()->hasFile($attribute_name) &&
@@ -48,7 +49,12 @@ trait HasUploadFields
         if (request()->hasFile($attribute_name) && request()->file($attribute_name)->isValid()) {
             // 1. Generate a new file name
             $file = request()->file($attribute_name);
-            $new_file_name = md5($file->getClientOriginalName().random_int(1, 9999).time()).'.'.$file->getClientOriginalExtension();
+            if($destination_filename){
+                $new_file_name = $destination_filename.'.'.$file->getClientOriginalExtension();
+            }
+            else {
+                $new_file_name = md5($file->getClientOriginalName().random_int(1, 9999).time()).'.'.$file->getClientOriginalExtension();
+            }
 
             // 2. Move the new file to the correct path
             $file_path = $file->storeAs($destination_path, $new_file_name, $disk);


### PR DESCRIPTION
Add an optional destination filename for the uploadFileToDisk method

## WHY

Sometimes we need/want to define a filename for uploaded files.

### BEFORE - What was wrong? What was happening before this PR?

Impossible de define a filename for the uploaded files. It's only a random filename.

### AFTER - What is happening after this PR?

You can easily pass an optional filename to your uploaded files


## HOW

### How did you achieve that, in technical terms?

I added an optional param "destination_filename" to uploadFileToDisk method to define a filename to the uploaded files if we need it.




### Is it a breaking change?

No


### How can we test the before & after?

Add a destination_filename param in the uploadFileToDisk method
